### PR TITLE
Feature/minor additions

### DIFF
--- a/src/PharoTransformationLanguage/Object.extension.st
+++ b/src/PharoTransformationLanguage/Object.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Object }
+
+{ #category : #'*PharoTransformationLanguage' }
+Object >> MTLequalsTo: otherObject [
+	^ self = otherObject 
+]

--- a/src/PharoTransformationLanguage/PTLMatcherResult.class.st
+++ b/src/PharoTransformationLanguage/PTLMatcherResult.class.st
@@ -41,3 +41,17 @@ PTLMatcherResult >> isMatch [
 PTLMatcherResult >> isMatch: aBoolean [ 
 	isMatch := aBoolean
 ]
+
+{ #category : #test }
+PTLMatcherResult >> isPartialMatch [
+	^ isMatch not and: [ context isNotEmpty ]
+]
+
+{ #category : #accessor }
+PTLMatcherResult >> printString [
+	^ '{1} ({2}, {3})'
+		format:
+			{super printString.
+			isMatch asString.
+			context asString}
+]

--- a/src/PharoTransformationLanguage/PTLMatcherSubPatternWrapper.class.st
+++ b/src/PharoTransformationLanguage/PTLMatcherSubPatternWrapper.class.st
@@ -38,7 +38,7 @@ PTLMatcherSubPatternWrapper >> hasMatch: aValue withContext: aContext [
 			  attributeTmp := [ 
 			                  (aValue class slotNamed: selector) read: aValue ]
 				                  on: Error
-				                  do: [ aValue perform: selector ] copy.
+				                  do: [ aValue perform: selector ].
 			  self flag: #toClean.
 			  attributeTmp := self convert: attributeTmp.
 


### PR DESCRIPTION
Some minor additions to have:

* a `MTLequalsTo:` on `Object` with a default implementation
* remove a useless copy
* add a convenient `printString` implementation for `MatcherResult`